### PR TITLE
Implementing interactive config init mode

### DIFF
--- a/concord_cli/config.py
+++ b/concord_cli/config.py
@@ -1,10 +1,11 @@
 import os
+import sys
 import json
 import argparse
 from functools import partial
+from concord_cli.utils import *
 
 CONFIG_FILENAME = '.concord.cfg'
-
 CONCORD_DEFAULTS = { 'zookeeper_path' : '/concord',
                      'zookeeper_hosts' : 'localhost:2181',
                      'scheduler_address' : 'localhost:11219' }
@@ -13,8 +14,10 @@ def generate_options():
     parser = argparse.ArgumentParser()
     subparser = parser.add_subparsers()
 
-    # Init command takes one optional argument 'parameters'
+    # Init command takes two optional arguments 'location' and 'parameters'
     init_parser = subparser.add_parser('init', help='Create concord cli defaults')
+    init_parser.add_argument('-l', '--location', default="~",
+                             help="location of settings file, defaults to ~")
     init_parser.add_argument('-p', '--parameters', nargs='+', type=str,
                              help='Custom cli defaults, i.e. k1=v1 k2=v2')
     init_parser.set_defaults(which='init')
@@ -30,41 +33,29 @@ def generate_options():
 
     return parser
 
-def find_config(src):
-    """ recursively searches .. until it finds a file named CONFIG_FILENAME
-    will return None in the case of no matches or the abspath if found"""
-    filepath = os.path.join(src, CONFIG_FILENAME)
-    if os.path.isfile(filepath):
-        return filepath
-    elif src == '/':
-        return None
-    else:
-        return find_config(os.path.dirname(src))
-
-def fetch_config(location, callback):
-    filepath = find_config(location)
+def fetch_config(location, callback, default_path=None):
+    """ Attempts to find file starting at location. Upon success the file
+    will be opened and contents passed into callback"""
+    filepath = find_config(location, CONFIG_FILENAME)
     if filepath is None:
-        print 'Could not find a configuration file'
-        return
+        print 'While searching recursively upwards (starting from %s), ' \
+            'a configuration file could not be found...' % location
+        return default_path
 
     with open(filepath, 'r') as datafile:
         config_data = json.load(datafile)
 
-    callback(config_data, filepath)
-
-def validate_config_params(config_params):
-    """ verifys that any user given keys are valid defaults"""
-    valid_config_keys = CONCORD_DEFAULTS.keys()
-    def validate(key):
-        return key in valid_config_keys
-
-    return all(map(validate, config_params.keys()))
-
-def pairs_todict(kvpair_list):
-    """ Transform list -> dict i.e. [a=b, c=d] -> {'a':'b', 'c':'d'}"""
-    return { k:v for k, v in map(lambda c: c.split('='), kvpair_list) }
+    return callback(config_data, filepath)
 
 def write_defaults(new_defaults, current, writepath):
+    """ Writes 'new_defaults' to disk at 'writepath' using 'current' for
+    default valies that 'new_defaults' may be omitting"""
+    def validate_config_params(config_params):
+        valid_config_keys = CONCORD_DEFAULTS.keys()
+        def validate(key):
+            return key in valid_config_keys
+        return all(map(validate, config_params.keys()))
+
     if new_defaults is not None:
         if not validate_config_params(new_defaults):
             raise Exception("Attempting to set unrecognized parameter")
@@ -73,26 +64,36 @@ def write_defaults(new_defaults, current, writepath):
     with open(writepath , 'w') as outfile:
         json.dump(current, outfile)
 
-def init(new_defaults):
-    filepath = find_config(os.getcwd())
-    if filepath is not None:
-        print '%s already exists in %s' \
-            % (CONFIG_FILENAME, os.path.realpath(filepath))
+def init(location, new_defaults=None):
+    """ Creates config_file in location, asking user to overwrite if already
+    exists. Then prompts user for default values and writes to disk if -p
+    option has not been used"""
+    def duplicate_prompt(config_data, fpath):
+        print 'config_file already exits in', fpath
         inpt = raw_input('Overwrite? [y|n] ')
-        if inpt != "y":
-            print 'Exiting'
-            return
-    else:
-        filepath = os.path.join(os.getcwd(), CONFIG_FILENAME)
+        return fpath if inpt == "y" else sys.exit(1)
 
-    # Append defaults with user params, user params take precedence
-    print 'Creating %s with defaults...' % CONFIG_FILENAME
+    default_path = os.path.join(os.path.expanduser(location), CONFIG_FILENAME)
+    filepath = fetch_config(os.getcwd(), duplicate_prompt, default_path)
+
+    if new_defaults is None:
+        def prompt_default(k, v):
+            inpt = raw_input('-- for key "%s" value will be ["%s"]: ' % (k,v))
+            return v if inpt == "" else inpt
+
+        print '\nCreating %s, select or overwrite default values: ' % filepath
+        print 'When prompted, hit enter to take the default or enter a new value'
+        new_defaults = { k:prompt_default(k,v) for k,v in CONCORD_DEFAULTS.iteritems() }
+
     write_defaults(new_defaults, CONCORD_DEFAULTS.copy(), filepath)
+    print '\nWrite successful, these are the new settings: '
+    fetch_config(filepath, show)
 
 def show(config_data, filepath):
+    """ Prints the contents of the config_file to stdout"""
     def pretty_print(kvpair):
         print '%s=%s' % kvpair
-    print 'Concord configuration data: '
+    print 'Concord configuration data: ', filepath
     map(pretty_print, config_data.iteritems())
 
 def main():
@@ -101,10 +102,9 @@ def main():
     if options.which == 'show':
         fetch_config(os.getcwd(), show)
     else:
-        argsdict = None if options.parameters is None else \
-                   pairs_todict(options.parameters)
+        argsdict = pairs_todict(options.parameters)
         if options.which == 'init':
-            init(argsdict)
+            init(options.location, argsdict)
         elif options.which == 'set':
             fetch_config(os.getcwd(), partial(write_defaults, argsdict))
 

--- a/concord_cli/config.py
+++ b/concord_cli/config.py
@@ -5,7 +5,6 @@ import argparse
 from functools import partial
 from concord_cli.utils import *
 
-CONFIG_FILENAME = '.concord.cfg'
 CONCORD_DEFAULTS = { 'zookeeper_path' : '/concord',
                      'zookeeper_hosts' : 'localhost:2181',
                      'scheduler_address' : 'localhost:11219' }
@@ -16,7 +15,7 @@ def generate_options():
 
     # Init command takes two optional arguments 'location' and 'parameters'
     init_parser = subparser.add_parser('init', help='Create concord cli defaults')
-    init_parser.add_argument('-l', '--location', default="~",
+    init_parser.add_argument('-c', '--config', default="~",
                              help="location of settings file, defaults to ~")
     init_parser.add_argument('-p', '--parameters', nargs='+', type=str,
                              help='Custom cli defaults, i.e. k1=v1 k2=v2')
@@ -36,7 +35,7 @@ def generate_options():
 def fetch_config(location, callback, default_path=None):
     """ Attempts to find file starting at location. Upon success the file
     will be opened and contents passed into callback"""
-    filepath = find_config(location, CONFIG_FILENAME)
+    filepath = find_config(location, CONCORD_FILENAME)
     if filepath is None:
         print 'While searching recursively upwards (starting from %s), ' \
             'a configuration file could not be found...' % location
@@ -73,7 +72,7 @@ def init(location, new_defaults=None):
         inpt = raw_input('Overwrite? [y|n] ')
         return fpath if inpt == "y" else sys.exit(1)
 
-    default_path = os.path.join(os.path.expanduser(location), CONFIG_FILENAME)
+    default_path = os.path.join(os.path.expanduser(location), CONCORD_FILENAME)
     filepath = fetch_config(os.getcwd(), duplicate_prompt, default_path)
 
     if new_defaults is None:
@@ -104,7 +103,7 @@ def main():
     else:
         argsdict = pairs_todict(options.parameters)
         if options.which == 'init':
-            init(options.location, argsdict)
+            init(options.config, argsdict)
         elif options.which == 'set':
             fetch_config(os.getcwd(), partial(write_defaults, argsdict))
 

--- a/concord_cli/deploy.py
+++ b/concord_cli/deploy.py
@@ -118,7 +118,7 @@ def generate_options():
 def validate_options(options, parser):
     if not options.config:
         parser.error("need to specify config file")
-    config = default_options(options)
+    default_options(options)
 
 def tar_file_list(white_list, black_list):
     """

--- a/concord_cli/kill_task.py
+++ b/concord_cli/kill_task.py
@@ -38,7 +38,7 @@ def generate_options():
 def validate_options(options, parser):
     if options.all and options.task_id:
         parser.error('You are using task_id and passing the all flag')
-    config = default_options(options)
+    default_options(options)
 
 def kill(zookeeper, zk_path, task_ids):
     if len(task_ids) == 0:

--- a/concord_cli/print_graph.py
+++ b/concord_cli/print_graph.py
@@ -76,7 +76,7 @@ def print_dot(meta, filename):
 def main():
     parser = generate_options()
     (options, args) = parser.parse_args()
-    config = default_options(options)
+    default_options(options)
 
     print_dot(get_zookeeper_metadata(options.zookeeper, options.zk_path),
               options.filename)

--- a/concord_cli/tracer.py
+++ b/concord_cli/tracer.py
@@ -32,7 +32,7 @@ def generate_options():
     return parser
 
 def validate_options(options, parser):
-    config = default_options(options)
+    default_options(options)
     if not options.trace_id:
         parser.error("need to specify trace id")
     if not options.scheduler:

--- a/concord_cli/utils.py
+++ b/concord_cli/utils.py
@@ -3,7 +3,6 @@ import json
 import logging
 from thrift import Thrift
 from kazoo.client import KazooClient
-from concord_cli.config import find_config
 from concord_cli.generated.concord.internal.thrift.ttypes import *
 from concord_cli.generated.concord.internal.thrift import (
     BoltTraceAggregatorService,
@@ -105,16 +104,34 @@ def get_trace_service_client(ip, port):
 def flatten(xs):
     return reduce(lambda m, x: m + x, xs,[])
 
+def pairs_todict(kvpair_list):
+    """ Transform list -> dict i.e. [a=b, c=d] -> {'a':'b', 'c':'d'}"""
+    return None if kvpair_list is None else \
+    { k:v for k, v in map(lambda c: c.split('='), kvpair_list) }
+
+def find_config(src, config_file):
+    """ recursively searches .. until it finds a file named config_file
+    will return None in the case of no matches or the abspath if found"""
+    filepath = os.path.join(src, config_file)
+    if os.path.isfile(filepath):
+        return filepath
+    elif src == '/':
+        return None
+    else:
+        return find_config(os.path.dirname(src), config_file)
+
 def default_options(opts):
-    location = find_config(os.getcwd())
+    location = find_config(os.getcwd(), '.concord.cfg')
     if location is None:
         return
     with open(location, 'r') as data_file:
         config_data = json.load(data_file)
     opts_methods = dir(opts)
     if 'zookeeper' in opts_methods:
-        opts.zookeepers = config_data['zookeeper_hosts']
+        opts.zookeeper = config_data['zookeeper_hosts']
     if 'zk_path' in opts_methods:
         opts.zk_path = config_data['zookeeper_path']
     if 'scheduler' in opts_methods:
         opts.scheduler = config_data['scheduler_address']
+
+    return opts

--- a/concord_cli/utils.py
+++ b/concord_cli/utils.py
@@ -19,6 +19,8 @@ logging.basicConfig()
 logger = logging.getLogger('cmd.utils')
 logger.setLevel(logging.INFO)
 
+CONCORD_FILENAME = '.concord.cfg'
+
 class ContextDirMgr:
     def __init__(self, path):
         self.new_dir = os.path.dirname(os.path.abspath(path))
@@ -121,7 +123,7 @@ def find_config(src, config_file):
         return find_config(os.path.dirname(src), config_file)
 
 def default_options(opts):
-    location = find_config(os.getcwd(), '.concord.cfg')
+    location = find_config(os.getcwd(), CONCORD_FILENAME)
     if location is None:
         return
     with open(location, 'r') as data_file:
@@ -133,5 +135,3 @@ def default_options(opts):
         opts.zk_path = config_data['zookeeper_path']
     if 'scheduler' in opts_methods:
         opts.scheduler = config_data['scheduler_address']
-
-    return opts

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_reqs = parse_requirements(reqs_file, session=pip.download.PipSession())
 # e.g. ['django==1.5.1', 'mezzanine==1.4.6']
 reqs = [str(ir.req) for ir in install_reqs]
 
-setup(version='0.1.4.1',
+setup(version='0.1.5',
       name='concord',
       description='python concord command line tools',
       scripts=['concord'],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_reqs = parse_requirements(reqs_file, session=pip.download.PipSession())
 # e.g. ['django==1.5.1', 'mezzanine==1.4.6']
 reqs = [str(ir.req) for ir in install_reqs]
 
-setup(version='0.1.4',
+setup(version='0.1.4.1',
       name='concord',
       description='python concord command line tools',
       scripts=['concord'],


### PR DESCRIPTION
- Config init asks user to supply alternative values for each k,v pair
  in config.py options dict.
- Config init also takes another optional parameter called --location
  which the user can use to place .config.cfg in. The default is ~
- Fixed bug where zookeeper hosts wasn't being properly taken.
- Moved some general methods into utils.py
- Incrementing version to 1.4.1